### PR TITLE
CI actually builds for all targets. Added musl.

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -54,12 +54,10 @@ jobs:
           toolchain: stable minus 2 releases
       - name: 64-bit Valgrind
         run: |
-          cargo build --example shutdown --target x86_64-unknown-linux-gnu --features extras,log
-          valgrind --error-exitcode=1 --leak-check=full --show-leak-kinds=all target/x86_64-unknown-linux-gnu/debug/examples/shutdown
-          cargo build --example shutdown_unix --target x86_64-unknown-linux-gnu --features extras,log
-          valgrind --error-exitcode=1 --leak-check=full --show-leak-kinds=all target/x86_64-unknown-linux-gnu/debug/examples/shutdown_unix
-          cargo build --example shutdown_multiple --target x86_64-unknown-linux-gnu --features extras,log
-          valgrind --error-exitcode=1 --leak-check=full --show-leak-kinds=all target/x86_64-unknown-linux-gnu/debug/examples/shutdown_multiple
+          cargo build --examples
+          valgrind --error-exitcode=1 --leak-check=full --show-leak-kinds=all target/debug/examples/shutdown
+          valgrind --error-exitcode=1 --leak-check=full --show-leak-kinds=all target/debug/examples/shutdown_unix
+          valgrind --error-exitcode=1 --leak-check=full --show-leak-kinds=all target/debug/examples/shutdown_multiple
 
   build_linux:
     name: Build Linux
@@ -69,6 +67,8 @@ jobs:
         target:
           - "x86_64-unknown-linux-gnu"
           - "i686-unknown-linux-gnu"
+          - "x86_64-unknown-linux-musl"
+          - "i686-unknown-linux-musl"
           - "aarch64-unknown-linux-gnu"
     env:
       RUSTFLAGS: "-D warnings"
@@ -76,6 +76,9 @@ jobs:
     steps:
       - name: Update sources
         run: sudo apt update
+      - name: Install musl deps
+        run: sudo apt install musl-dev musl-tools
+        if: ${{ contains(matrix.target, 'musl') }}
       - name: Install libc6-dev-i386
         run: sudo apt install libc6-dev-i386
         if: ${{ contains(matrix.target, 'i686') }}
@@ -90,12 +93,15 @@ jobs:
         with:
           targets: ${{ matrix.target }}
           toolchain: stable minus 2 releases
-      - name: Build gnu target
+      - name: Build with all features
         run: |
           cargo build --all-features --target ${{ matrix.target }}
-          cargo build --no-default-features
-          cargo build --examples
-          cargo build --examples --all-features
+          cargo build --examples --all-features --target ${{ matrix.target }}
+        if: ${{ !(contains(matrix.target, 'musl') || contains(matrix.target, 'aarch64')) }}
+      - name: Build with no and default features
+        run: |
+          cargo build --target ${{ matrix.target }}
+          cargo build --no-default-features --target ${{ matrix.target }}
 
   build_windows:
     name: Build Windows
@@ -129,9 +135,8 @@ jobs:
       - name: Build Windows
         run: |
           cargo build --all-features --target ${{ matrix.target }}
-          cargo build --no-default-features
-          cargo build --examples
-          cargo build --examples --all-features
+          cargo build --no-default-features --target ${{ matrix.target }}
+          cargo build --examples --target ${{ matrix.target }}
 
   test_windows:
     name: Test Windows

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -54,7 +54,7 @@ jobs:
           toolchain: stable minus 2 releases
       - name: 64-bit Valgrind
         run: |
-          cargo build --examples
+          cargo build --examples --features extras,log
           valgrind --error-exitcode=1 --leak-check=full --show-leak-kinds=all target/debug/examples/shutdown
           valgrind --error-exitcode=1 --leak-check=full --show-leak-kinds=all target/debug/examples/shutdown_unix
           valgrind --error-exitcode=1 --leak-check=full --show-leak-kinds=all target/debug/examples/shutdown_multiple

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["http", "server", "http-server"]
 categories = ["web-programming::http-server", "network-programming"]
 
 [dependencies]
-backtrace = { version = "0.3.74", optional = true}
+backtrace = { version = "0.3.74", optional = true }
 constutils = { path = "constutils" }
 getrandom = { version = "0.3", optional = true }
 log = { version = "^0.4.22", optional = true }
@@ -31,7 +31,7 @@ rust-tls-duplex-stream = { version = "0.1.1", optional = true }
 libc = { version = "*", optional = true }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.59.0", optional = true, features = ["Win32_Networking_WinSock"]}
+windows-sys = { version = "0.59.0", optional = true, features = ["Win32_Networking_WinSock"] }
 
 [dev-dependencies]
 rustls-pemfile = "2.2.0"
@@ -55,46 +55,36 @@ unwrap_used = "warn"
 
 [[example]]
 name = "basic"
-path = "examples/basic.rs"
-required-features = ["log", "extras"]
+required-features = ["extras", "log"]
 
 [[example]]
 name = "shutdown"
-path = "examples/shutdown.rs"
 required-features = ["extras", "log"]
 
 [[example]]
 name = "shutdown_multiple"
-path = "examples/shutdown_multiple.rs"
 required-features = ["extras", "log"]
-
 
 [[example]]
 name = "shutdown_unix"
-path = "examples/shutdown_unix.rs"
 required-features = ["extras", "log"]
 
 [[example]]
 name = "tls"
-path = "examples/tls.rs"
-required-features = ["tls", "extras", "log"]
+required-features = ["extras", "log", "tls"]
 
 [[example]]
 name = "static-content"
-path = "examples/static-content.rs"
 required-features = ["extras"]
 
 [[example]]
 name = "wildcard"
-path = "examples/wildcard.rs"
 required-features = ["extras"]
 
 [[example]]
 name = "websocket"
-path = "examples/websocket.rs"
 required-features = ["extras", "log"]
 
 [[example]]
 name = "unix"
-path = "examples/unix.rs"
 required-features = ["extras", "log"]


### PR DESCRIPTION
We accidentally weren't building for all targets. I also added `musl`. I gate musl and aarch64 for default features (and no features, which is the same, as we have no default features) because rustls is a huge pain.