### PR TITLE
optionally obmit response body for response to http HEAD requests

### DIFF
--- a/src/http/response.rs
+++ b/src/http/response.rs
@@ -39,6 +39,23 @@ pub struct Response {
   pub(crate) headers: Headers,
   /// The body of the response.
   pub body: Option<ResponseBody>,
+
+  /// If this field is set to true then tii will not send the body over the wire.
+  /// The response headers that would describe the omitted body will still be sent.
+  /// This should only be set to true as a response to HTTP HEAD requests.
+  ///
+  /// IMPLEMENTATION DETAIL: Setting this value to true forces 'Connection: Close'.
+  /// In case of HTTP 0.9 this value is completely ignored and the body is still sent.
+  ///
+  /// Use this field only if absolutely necessary!
+  ///
+  /// How HTTP clients will expect HEAD requests in regard to response body and Content-Lengths field values is highly dependent on the client
+  /// Every client seems to expect something else. Some clients prefer a response that simply has `Response::without_body`,
+  /// this however will also remove the Content-Length header! Other clients want the Content-Length header but
+  /// no actual body. The forcing of 'Connection: Close' is a safety measure because otherwise clients that do
+  /// actually want to read the body will just hang until timeout waiting for the body which
+  /// we will never send.
+  pub omit_body: bool,
 }
 
 impl Response {
@@ -46,7 +63,7 @@ impl Response {
   /// Automatically sets the HTTP version to "HTTP/1.1", sets no headers, and creates an empty body.
   pub fn new(status_code: impl Into<StatusCode>) -> Self {
     let status_code = status_code.into();
-    Self { status_code, headers: Headers::new(), body: None }
+    Self { status_code, headers: Headers::new(), body: None, omit_body: false }
   }
 
   /// HTTP 200 OK with body.
@@ -657,7 +674,9 @@ impl Response {
           }
         }
         destination.write_all(b"\r\n")?;
-        body.write_to_http(request_id, destination)?;
+        if !self.omit_body {
+          body.write_to_http(request_id, destination)?;
+        }
         destination.flush()?;
         return Ok(());
       }
@@ -678,7 +697,9 @@ impl Response {
 
       destination.write_all(b"\r\n")?;
 
-      body.write_to_http(request_id, destination)?;
+      if !self.omit_body {
+        body.write_to_http(request_id, destination)?;
+      }
       destination.flush()?;
       return Ok(());
     }

--- a/src/tii_router_builder.rs
+++ b/src/tii_router_builder.rs
@@ -278,7 +278,8 @@ impl RouterBuilder {
       .route_post(route, wrapped.clone())?
       .route_patch(route, wrapped.clone())?
       .route_delete(route, wrapped.clone())?
-      .route_options(route, wrapped)
+      .route_options(route, wrapped.clone())?
+      .route_head(route, wrapped)
   }
 
   /// Helper fn to make some builder code look a bit cleaner.
@@ -345,6 +346,12 @@ impl RouterBuilder {
     handler: T,
   ) -> TiiResult<Self> {
     self.route_method(HttpMethod::Options, route, handler)
+  }
+
+  /// Adds a route that will handle the HEAD http method.
+  /// The endpoint will be called for any media type.
+  pub fn route_head<T: HttpEndpoint + 'static>(self, route: &str, handler: T) -> TiiResult<Self> {
+    self.route_method(HttpMethod::Head, route, handler)
   }
 
   /// Helper fn that will just call the passed closure,

--- a/src/tii_server.rs
+++ b/src/tii_server.rs
@@ -260,6 +260,10 @@ impl Server {
           .unwrap_or_else(|e| self.fallback_error_handler(&mut context, e)),
       });
 
+      if response.omit_body {
+        context.force_connection_close();
+      }
+
       keep_alive &= !context.is_connection_close_forced();
 
       let id = context.id();

--- a/tests/tc69.rs
+++ b/tests/tc69.rs
@@ -1,0 +1,25 @@
+use crate::mock_stream::MockStream;
+use tii::{HttpMethod, MimeType, TiiResult};
+use tii::{RequestContext, Response, ServerBuilder};
+
+mod mock_stream;
+fn dummy_route(request: &RequestContext) -> TiiResult<Response> {
+  if request.get_method() == HttpMethod::Head {
+    let mut resp = Response::ok(vec![b'A'; 4], MimeType::TextPlain);
+    resp.omit_body = true;
+    return Ok(resp);
+  }
+  Ok(Response::ok(vec![b'A'; 4], MimeType::TextPlain))
+}
+#[test]
+pub fn tc69() {
+  let server =
+    ServerBuilder::default().router(|rt| rt.route_any("/*", dummy_route)).expect("ERR").build();
+
+  let stream = MockStream::with_str("GET /dummy HTTP/1.1\r\nConnection: keep-alive\r\n\r\nHEAD /dummy HTTP/1.1\r\nConnection: keep-alive\r\n\r\n");
+  let con = stream.to_stream();
+  server.handle_connection(con).unwrap();
+
+  let data = stream.copy_written_data_to_string();
+  assert_eq!(data, "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nConnection: Keep-Alive\r\nContent-Length: 4\r\n\r\nAAAAHTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nConnection: Close\r\nContent-Length: 4\r\n\r\n");
+}


### PR DESCRIPTION
add ability for user endpoint to declare the body should be omitted from the response. This is needed for some specific clients as a response to http head requests.